### PR TITLE
Add adjustable timer

### DIFF
--- a/src/FocusApp/App.cs
+++ b/src/FocusApp/App.cs
@@ -1,9 +1,18 @@
-﻿using FocusApp.Resources;
+﻿using AuthenticationServices;
+using CommunityToolkit.Maui.Markup;
+using FocusApp.Resources;
 
 namespace FocusApp
 {
     class App : Application
     {
+        public static event Action? WindowCreated;
+        public static event Action? WindowActivated;
+        public static event Action? WindowDeactivated;
+        public static event Action? WindowStopped;
+        public static event Action? WindowResumed;
+        public static event Action? WindowDestroying;
+
         /// <summary>
         /// Create a new instance of the application with the styling resources and 
         /// a <see cref="Shell"/> that only acts as a container for the <see cref="MainPage"/>.
@@ -13,6 +22,23 @@ namespace FocusApp
             Resources = new AppStyles();
 
             MainPage = new Shell() { CurrentItem = new MainPage() };
+        }
+
+        /// <summary>
+        /// Setup the app to relay app lifecycle events to static action events.
+        /// </summary>
+        protected override Window CreateWindow(IActivationState? activationState)
+        {
+            Window window = base.CreateWindow(activationState);
+
+            window.Created += (object? sender, EventArgs e) => WindowCreated?.Invoke();
+            window.Activated += (object? sender, EventArgs e) => WindowActivated?.Invoke();
+            window.Deactivated += (object? sender, EventArgs e) => WindowDeactivated?.Invoke();
+            window.Stopped += (object? sender, EventArgs e) => WindowStopped?.Invoke();
+            window.Resumed += (object? sender, EventArgs e) => WindowResumed?.Invoke();
+            window.Destroying += (object? sender, EventArgs e) => WindowDestroying?.Invoke();
+
+            return window;
         }
     }
 }

--- a/src/FocusApp/App.cs
+++ b/src/FocusApp/App.cs
@@ -1,6 +1,4 @@
-﻿using AuthenticationServices;
-using CommunityToolkit.Maui.Markup;
-using FocusApp.Resources;
+﻿using FocusApp.Resources;
 
 namespace FocusApp
 {

--- a/src/FocusApp/Helpers/TimerHelper.cs
+++ b/src/FocusApp/Helpers/TimerHelper.cs
@@ -72,7 +72,7 @@ internal class TimerHelper : INotifyPropertyChanged
         private set => SetProperty(ref _toggleTimerButtonBackgroudColor, value);
     }
 
-    private int TimeLeft
+    public int TimeLeft
     {
         get => _timeLeft;
         set
@@ -106,12 +106,12 @@ internal class TimerHelper : INotifyPropertyChanged
     public TimerHelper()
     {
         _timerDisplay = new TimerDto();
-        _lastFocusTimerDuration = TimeSpan.FromMinutes(15).Seconds;
-        _lastBreakTimerDuration = TimeSpan.FromMinutes(5).Seconds;
+        _lastFocusTimerDuration = (int)TimeSpan.FromMinutes(5).TotalSeconds;
+        _lastBreakTimerDuration = (int)TimeSpan.FromMinutes(5).TotalSeconds;
         _state = TimerState.StoppedPreFocus;
         _toggleTimerButtonText = "Start Focus";
         _toggleTimerButtonBackgroudColor = AppStyles.Palette.Celeste;
-        TimeLeft = TimeSpan.FromMinutes(15).Seconds;
+        TimeLeft = _lastFocusTimerDuration;
         ToggleTimer += TransitionToNextState;
     }
 
@@ -119,21 +119,6 @@ internal class TimerHelper : INotifyPropertyChanged
     {
         return (_state == TimerState.FocusCountdown ||
                 _state == TimerState.BreakCountdown);
-    }
-
-    /// <summary>
-    /// Increment or decrement the timer duration.
-    /// </summary>
-    public void onTimeStepperButtonClick(TimerView.TimerButton clickedButton)
-    {
-        int stepAmount = 60;
-
-        TimeLeft = clickedButton switch
-        {
-            TimerView.TimerButton.Up => TimeLeft + stepAmount,
-            TimerView.TimerButton.Down => TimeLeft - stepAmount,
-            _ => 0
-        };
     }
 
     /// <summary>
@@ -279,7 +264,7 @@ internal class TimerHelper : INotifyPropertyChanged
             TimeSpan timeElapsed = DateTime.Now - _lastKnownTime.Value;
             _lastKnownTime = null;
 
-            TimeLeft -= timeElapsed.Seconds;
+            TimeLeft -= (int)timeElapsed.TotalSeconds;
             if (TimeLeft <= 0) 
             {
                 TransitionToNextState();

--- a/src/FocusApp/Helpers/TimerHelper.cs
+++ b/src/FocusApp/Helpers/TimerHelper.cs
@@ -1,62 +1,126 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 
-namespace FocusApp.Helpers
-{
-    internal class TimerHelper
+namespace FocusApp.Helpers;
+
+internal class TimerHelper : INotifyPropertyChanged
+{   
+    public class Timer
     {
-        private int _counter = 0;
-        private DateTime? lastKnownTime;
-        private bool IsTimerActive = false;
+        [DisplayFormat(DataFormatString = "{0:00}")]
+        public int HourTime { get; set; }
 
-        public TimerHelper()
+        [DisplayFormat(DataFormatString = "{0:00}")]
+        public int MinuteTime { get; set; }
+
+        [DisplayFormat(DataFormatString = "{0:00}")]
+        public int SecondTime { get; set; }
+
+        public override string ToString()
         {
-            onTimerStart();
-        }
+            string hour = (HourTime != 0) ? $"{string.Format("{0:00}", HourTime)}:" : "";
+            string minute = string.Format("{0:00}", MinuteTime);
+            string second = string.Format("{0:00}", SecondTime);
 
-        private void onTimerStart()
-        {
-            App.WindowDeactivated += onAppMinimized;
-            App.WindowStopped += onAppMinimized;
-
-            IsTimerActive = true;
-        }
-
-        private void onTimerStop()
-        {
-
-            IsTimerActive = false;
-        }
-
-        private void onAppMinimized()
-        {
-            App.WindowDeactivated -= onAppMinimized;
-            App.WindowStopped -= onAppMinimized;
-
-            App.WindowActivated += onAppResumed;
-
-            lastKnownTime = DateTime.Now;
-        }
-        
-        private void onAppResumed()
-        {
-            App.WindowResumed -= onAppResumed;
-            App.WindowActivated -= onAppResumed;
-
-            App.WindowDeactivated += onAppMinimized;
-            App.WindowStopped += onAppMinimized;
-            
-            TimeSpan? timeElapsed = null;
-            if (lastKnownTime != null)
-            {
-                timeElapsed = DateTime.Now - lastKnownTime.Value;
-                lastKnownTime = null;
-            }
-
-            _counter -= timeElapsed.Value.Seconds;
+            return $"{hour}{minute}:{second}";
         }
     }
+
+    private Timer _timerDisplay;
+    public Timer TimerDisplay
+    {
+        get => _timerDisplay;
+        set => SetProperty(ref _timerDisplay, value);
+    }
+
+    private int _timeLeft;
+
+    private DateTime? lastKnownTime;
+    private bool IsTimerActive = false;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public Action<int>? StartTimer { get; set; }
+
+    public Action? CancelTimer { get; set; }
+
+    public TimerHelper()
+    {
+        _timerDisplay = new Timer();
+        StartTimer += onTimerStart;
+    }
+
+    #region App Lifecycle Triggered Logic
+
+    private void onTimerStart(int timerSeconds)
+    {
+        App.WindowDeactivated += onAppMinimized;
+        App.WindowStopped += onAppMinimized;
+
+        _timeLeft = timerSeconds;
+        IsTimerActive = true;
+
+        var timer = Application.Current?.Dispatcher.CreateTimer();
+        timer.Interval = TimeSpan.FromMilliseconds(1000);
+        timer.Tick += (sender, eventArgs) =>
+        {
+            _timeLeft--;
+            TimerDisplay = new Timer
+            {
+                HourTime = (int)Math.Floor(_timeLeft / 3600f),
+                MinuteTime = ((int)Math.Floor(_timeLeft / 60f)) % 60,
+                SecondTime = _timeLeft % 60
+            };
+        };
+        timer.Start();
+    }
+
+    private void onTimerStop()
+    {
+        IsTimerActive = false;
+    }
+
+    private void onAppMinimized()
+    {
+        App.WindowDeactivated -= onAppMinimized;
+        App.WindowStopped -= onAppMinimized;
+
+        App.WindowActivated += onAppResumed;
+
+        lastKnownTime = DateTime.Now;
+    }
+    
+    private void onAppResumed()
+    {
+        App.WindowResumed -= onAppResumed;
+        App.WindowActivated -= onAppResumed;
+
+        App.WindowDeactivated += onAppMinimized;
+        App.WindowStopped += onAppMinimized;
+        
+        TimeSpan? timeElapsed = null;
+        if (lastKnownTime != null)
+        {
+            timeElapsed = DateTime.Now - lastKnownTime.Value;
+            lastKnownTime = null;
+        }
+    }
+
+    #endregion
+
+    protected void SetProperty<T>(ref T backingStore, in T value, [CallerMemberName] in string propertyname = "")
+    {
+        if (EqualityComparer<T>.Default.Equals(backingStore, value))
+        {
+            return;
+        }
+
+        backingStore = value;
+
+        OnPropertyChanged(propertyname);
+    }
+
+    void OnPropertyChanged([CallerMemberName] string propertyName = "") =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }

--- a/src/FocusApp/Helpers/TimerHelper.cs
+++ b/src/FocusApp/Helpers/TimerHelper.cs
@@ -43,6 +43,7 @@ internal class TimerHelper : INotifyPropertyChanged
     private TimerDto _timerDisplay;
     private string _toggleTimerButtonText;
     private Color _toggleTimerButtonBackgroudColor;
+    private bool _areStepperButtonsVisible;
     private int _timeLeft;
     private IDispatcherTimer? _timer;
     private DateTime? _lastKnownTime;
@@ -72,12 +73,21 @@ internal class TimerHelper : INotifyPropertyChanged
         private set => SetProperty(ref _toggleTimerButtonBackgroudColor, value);
     }
 
+    public bool AreStepperButtonsVisible
+    {
+        get => _areStepperButtonsVisible;
+        private set => SetProperty(ref _areStepperButtonsVisible, value);
+    }
+
     public int TimeLeft
     {
         get => _timeLeft;
         set
         {
+            int maxTime = (int)TimeSpan.FromHours(5).TotalSeconds;
+
             value = (value < 0) ? 0 : value;
+            value = (value > maxTime) ? maxTime : value;
 
             SetProperty(ref _timeLeft, value);
             UpdateTimerDisplay();
@@ -112,6 +122,7 @@ internal class TimerHelper : INotifyPropertyChanged
         _toggleTimerButtonText = "Start Focus";
         _toggleTimerButtonBackgroudColor = AppStyles.Palette.Celeste;
         TimeLeft = _lastFocusTimerDuration;
+        AreStepperButtonsVisible = true;
         ToggleTimer += TransitionToNextState;
     }
 
@@ -143,24 +154,28 @@ internal class TimerHelper : INotifyPropertyChanged
                 onTimerStop();
                 ToggleTimerButtonText = "Start Focus";
                 ToggleTimerButtonBackgroudColor = AppStyles.Palette.Celeste;
+                AreStepperButtonsVisible = true;
                 break;
 
             case TimerState.FocusCountdown:
                 onTimerStart();
                 ToggleTimerButtonText = "Stop";
                 ToggleTimerButtonBackgroudColor = AppStyles.Palette.OrchidPink;
+                AreStepperButtonsVisible = false;
                 break;
 
             case TimerState.StoppedPreBreak:
                 onTimerStop();
                 ToggleTimerButtonText = "Start Break";
                 ToggleTimerButtonBackgroudColor = AppStyles.Palette.Celeste;
+                AreStepperButtonsVisible = true;
                 break;
 
             case TimerState.BreakCountdown:
                 onTimerStart();
                 ToggleTimerButtonText = "Skip";
                 ToggleTimerButtonBackgroudColor = AppStyles.Palette.OrchidPink;
+                AreStepperButtonsVisible = false;
                 break;
         }
     }

--- a/src/FocusApp/Helpers/TimerHelper.cs
+++ b/src/FocusApp/Helpers/TimerHelper.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FocusApp.Helpers
+{
+    internal class TimerHelper
+    {
+        private int _counter = 0;
+        private DateTime? lastKnownTime;
+        private bool IsTimerActive = false;
+
+        public TimerHelper()
+        {
+            onTimerStart();
+        }
+
+        private void onTimerStart()
+        {
+            App.WindowDeactivated += onAppMinimized;
+            App.WindowStopped += onAppMinimized;
+
+            IsTimerActive = true;
+        }
+
+        private void onTimerStop()
+        {
+
+            IsTimerActive = false;
+        }
+
+        private void onAppMinimized()
+        {
+            App.WindowDeactivated -= onAppMinimized;
+            App.WindowStopped -= onAppMinimized;
+
+            App.WindowActivated += onAppResumed;
+
+            lastKnownTime = DateTime.Now;
+        }
+        
+        private void onAppResumed()
+        {
+            App.WindowResumed -= onAppResumed;
+            App.WindowActivated -= onAppResumed;
+
+            App.WindowDeactivated += onAppMinimized;
+            App.WindowStopped += onAppMinimized;
+            
+            TimeSpan? timeElapsed = null;
+            if (lastKnownTime != null)
+            {
+                timeElapsed = DateTime.Now - lastKnownTime.Value;
+                lastKnownTime = null;
+            }
+
+            _counter -= timeElapsed.Value.Seconds;
+        }
+    }
+}

--- a/src/FocusApp/Resources/AppStyles.cs
+++ b/src/FocusApp/Resources/AppStyles.cs
@@ -15,6 +15,18 @@ public class AppStyles : ResourceDictionary
 							whiteColor = Color.FromArgb("FFFFFF"),
 							navigationBarButtonBackgroundColor = Color.FromArgb("#CEA9FF");
 
+	public static class Palette
+	{
+        public static readonly Color FairyTale = Color.FromArgb("FFCADB");
+        public static readonly Color OrchidPink = Color.FromArgb("FFBFD4");
+        public static readonly Color LightMauve = Color.FromArgb("E7C6FF");
+        public static readonly Color DarkMauve = Color.FromArgb("C8B6FF");
+        public static readonly Color Celeste = Color.FromArgb("BDEDE0");
+        public static readonly Color MintGreen = Color.FromArgb("BBDBD1");
+        public static readonly Color LightPeriwinkle = Color.FromArgb("BBD0FF");
+        public static readonly Color DarkPeriwinkle = Color.FromArgb("B8C0FF");
+    }
+
 	public AppStyles()
 	{
 		// all the colors and styles are being accessed directly except the below two

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -53,7 +53,7 @@ namespace FocusApp.Views
                     new Label
                     {
                         BindingContext = _timerHelper,
-                        FontSize = 30,
+                        FontSize = 60,
                         HorizontalOptions = LayoutOptions.Center,
                         VerticalOptions = LayoutOptions.Center
                     }
@@ -84,7 +84,6 @@ namespace FocusApp.Views
                     new Button
                     {
                         BindingContext = _timerHelper,
-                        BackgroundColor = AppStyles.Palette.Celeste,
                         TextColor = Colors.Black
                     }
                     .Font(size: 20)

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -59,7 +59,10 @@ namespace FocusApp.Views
                     }
                     .Row(Row.TimerDisplay)
                     .Column(Column.TimerAmount)
-                    .Bind(Label.TextProperty, getter: static (TimerHelper th) => th.TimerDisplay),
+                    .Bind(Label.TextProperty,
+                            getter: static (TimerHelper th) => th.TimerDisplay),
+
+                    // Island
 
                     // Increase Time Button
                     new Button
@@ -74,12 +77,13 @@ namespace FocusApp.Views
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.LeftTimerButton)
-                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimeStepperButtonClick(TimerButton.Up)),
+                    .Invoke(button => button.Clicked += (sender, eventArgs) => 
+                            _timerHelper.onTimeStepperButtonClick(TimerButton.Up)),
 
                     // Toggle Timer Button
                     new Button
                     {
-                        Text = "Start Timer",
+                        BindingContext = _timerHelper,
                         BackgroundColor = AppStyles.Palette.Celeste,
                         TextColor = Colors.Black
                     }
@@ -87,7 +91,12 @@ namespace FocusApp.Views
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.TimerAmount)
-                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.ToggleTimer.Invoke(button)),
+                    .Bind(Button.TextProperty,
+                            getter: static (TimerHelper th) => th.ToggleTimerButtonText)
+                    .Bind(Button.BackgroundColorProperty,
+                            getter: static (TimerHelper th) => th.ToggleTimerButtonBackgroudColor)
+                    .Invoke(button => button.Clicked += (sender, eventArgs) =>
+                            _timerHelper.ToggleTimer.Invoke()),
 
                     // Decrease Time Button
                     new Button

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -11,6 +11,7 @@ namespace FocusApp.Views
 
         enum Row { TopBar, TimerDisplay, Island, TimerButtons, BottomWhiteSpace }
         enum Column { LeftTimerButton, TimerAmount, RightTimerButton }
+        public enum TimerButton { Up, Down }
 
         public TimerView()
         {
@@ -57,7 +58,8 @@ namespace FocusApp.Views
                     .End()
                     .CenterVertical()
                     .Row(Row.TimerButtons)
-                    .Column(Column.LeftTimerButton),
+                    .Column(Column.LeftTimerButton)
+                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimerButtonClick(TimerButton.Up)),
 
                     new Label
                     {
@@ -74,14 +76,17 @@ namespace FocusApp.Views
                     {
                         Text = SolidIcons.ChevronDown,
                         BackgroundColor = Colors.Transparent,
-                        TextColor = Colors.Black,
+                        TextColor = Colors.Black
                     }
                     .Font(family: nameof(SolidIcons), size: 40)
                     .Start()
                     .CenterVertical()
                     .Row(Row.TimerButtons)
-                    .Column(Column.RightTimerButton),
+                    .Column(Column.RightTimerButton)
+                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimerButtonClick(TimerButton.Down)),
                 }
+
+                
             };
         }
     }

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -47,18 +47,21 @@ namespace FocusApp.Views
                     .Row(Row.TopBar)
                     .Top()
                     .Left()
+                    .Bind(IsVisibleProperty,
+                            getter: (TimerHelper th) => th.AreStepperButtonsVisible, source: _timerHelper)
                     .Invoke(b => b.Clicked += (sender, e) => { Content = new SettingsView(); }),
 
                     // Time Left Display
                     new Label
                     {
                         BindingContext = _timerHelper,
-                        FontSize = 60,
+                        FontSize = 70,
                         HorizontalOptions = LayoutOptions.Center,
                         VerticalOptions = LayoutOptions.Center
                     }
+                    .Center()
                     .Row(Row.TimerDisplay)
-                    .Column(Column.TimerAmount)
+                    .ColumnSpan(typeof(Column).GetEnumNames().Length)
                     .Bind(Label.TextProperty,
                             getter: static (TimerHelper th) => th.TimerDisplay),
 
@@ -75,24 +78,29 @@ namespace FocusApp.Views
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.LeftTimerButton)
+                    .Bind(IsVisibleProperty,
+                            getter: (TimerHelper th) => th.AreStepperButtonsVisible, source: _timerHelper)
                     .Invoke(button => button.Clicked += (sender, eventArgs) => 
                             onTimeStepperButtonClick(TimerButton.Up))
-                    .Invoke(button => button.Pressed += (sender, eventArgs) => onTimeStepperButtonPressed(TimerButton.Up))
-                    .Invoke(button => button.Released += (sender, eventArgs) => onTimeStepperButtonReleased()),
+                    .Invoke(button => button.Pressed += (sender, eventArgs) =>
+                            onTimeStepperButtonPressed(TimerButton.Up))
+                    .Invoke(button => button.Released += (sender, eventArgs) =>
+                            onTimeStepperButtonReleased()),
 
                     // Toggle Timer Button
                     new Button
                     {
                         BindingContext = _timerHelper,
-                        TextColor = Colors.Black
+                        TextColor = Colors.Black,
+                        CornerRadius = 20,
                     }
-                    .Font(size: 20)
+                    .Font(size: 20).Margins(left: 10, right: 10)
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.TimerAmount)
                     .Bind(Button.TextProperty,
                             getter: static (TimerHelper th) => th.ToggleTimerButtonText)
-                    .Bind(Button.BackgroundColorProperty,
+                    .Bind(BackgroundColorProperty,
                             getter: static (TimerHelper th) => th.ToggleTimerButtonBackgroudColor)
                     .Invoke(button => button.Clicked += (sender, eventArgs) =>
                             _timerHelper.ToggleTimer.Invoke()),
@@ -100,6 +108,7 @@ namespace FocusApp.Views
                     // Decrease Time Button
                     new Button
                     {
+                        BindingContext = _timerHelper,
                         Text = SolidIcons.ChevronDown,
                         BackgroundColor = Colors.Transparent,
                         TextColor = Colors.Black
@@ -109,9 +118,14 @@ namespace FocusApp.Views
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.RightTimerButton)
-                    .Invoke(button => button.Clicked += (sender, eventArgs) => onTimeStepperButtonClick(TimerButton.Down))
-                    .Invoke(button => button.Pressed += (sender, eventArgs) => onTimeStepperButtonPressed(TimerButton.Down))
-                    .Invoke(button => button.Released += (sender, eventArgs) => onTimeStepperButtonReleased()),
+                    .Bind(IsVisibleProperty, 
+                            getter: (TimerHelper th) => th.AreStepperButtonsVisible, source: _timerHelper )
+                    .Invoke(button => button.Clicked += (sender, eventArgs) =>
+                            onTimeStepperButtonClick(TimerButton.Down))
+                    .Invoke(button => button.Pressed += (sender, eventArgs) =>
+                            onTimeStepperButtonPressed(TimerButton.Down))
+                    .Invoke(button => button.Released += (sender, eventArgs) =>
+                            onTimeStepperButtonReleased()),
                 }
             };
         }
@@ -139,7 +153,7 @@ namespace FocusApp.Views
         public void onTimeStepperButtonPressed(TimerButton clickedButton)
         {
             _timeStepperTimer = Application.Current!.Dispatcher.CreateTimer();
-            _timeStepperTimer.Interval = TimeSpan.FromMilliseconds(250);
+            _timeStepperTimer.Interval = TimeSpan.FromMilliseconds(200);
             _timeStepperTimer.Tick += (sender, e) => onTimeStepperButtonClick(clickedButton);
             _timeStepperTimer.Start();
         }

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -7,6 +7,7 @@ namespace FocusApp.Views
 {
     internal class TimerView : ContentView
     {
+        private TimerHelper _timerHelper;
 
         enum Row { TopBar, TimerDisplay, Island, TimerButtons, BottomWhiteSpace }
         enum Column { LeftTimerButton, TimerAmount, RightTimerButton }

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Maui.Markup;
 using CommunityToolkit.Maui.Markup.LeftToRight;
 using FocusApp.Helpers;
+using FocusApp.Resources;
 using FocusApp.Resources.FontAwesomeIcons;
 
 namespace FocusApp.Views
@@ -34,6 +35,7 @@ namespace FocusApp.Views
                 BackgroundColor = Color.FromArgb("BBD0FF"),
                 Children =
                 {
+                    // Setting Button
                     new Button
                     {
                         Text = SolidIcons.Gears,
@@ -47,6 +49,19 @@ namespace FocusApp.Views
                     .Left()
                     .Invoke(b => b.Clicked += (sender, e) => { Content = new SettingsView(); }),
 
+                    // Time Left Display
+                    new Label
+                    {
+                        BindingContext = _timerHelper,
+                        FontSize = 30,
+                        HorizontalOptions = LayoutOptions.Center,
+                        VerticalOptions = LayoutOptions.Center
+                    }
+                    .Row(Row.TimerDisplay)
+                    .Column(Column.TimerAmount)
+                    .Bind(Label.TextProperty, getter: static (TimerHelper th) => th.TimerDisplay),
+
+                    // Increase Time Button
                     new Button
                     {
                         Text = SolidIcons.ChevronUp,
@@ -59,19 +74,22 @@ namespace FocusApp.Views
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.LeftTimerButton)
-                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimerButtonClick(TimerButton.Up)),
+                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimeStepperButtonClick(TimerButton.Up)),
 
-                    new Label
+                    // Toggle Timer Button
+                    new Button
                     {
-                        BindingContext = _timerHelper,
-                        FontSize = 30,
-                        HorizontalOptions = LayoutOptions.Center,
-                        VerticalOptions = LayoutOptions.Center
+                        Text = "Start Timer",
+                        BackgroundColor = AppStyles.Palette.Celeste,
+                        TextColor = Colors.Black
                     }
-                    .Row(Row.TimerDisplay)
+                    .Font(size: 20)
+                    .CenterVertical()
+                    .Row(Row.TimerButtons)
                     .Column(Column.TimerAmount)
-                    .Bind(Label.TextProperty, getter: static (TimerHelper th) => th.TimerDisplay),
+                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.ToggleTimer.Invoke(button)),
 
+                    // Decrease Time Button
                     new Button
                     {
                         Text = SolidIcons.ChevronDown,
@@ -83,10 +101,8 @@ namespace FocusApp.Views
                     .CenterVertical()
                     .Row(Row.TimerButtons)
                     .Column(Column.RightTimerButton)
-                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimerButtonClick(TimerButton.Down)),
+                    .Invoke(button => button.Clicked += (sender, eventArgs) => _timerHelper.onTimeStepperButtonClick(TimerButton.Down)),
                 }
-
-                
             };
         }
     }

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -1,17 +1,35 @@
 ﻿using CommunityToolkit.Maui.Markup;
 using CommunityToolkit.Maui.Markup.LeftToRight;
+using FocusApp.Helpers;
 using FocusApp.Resources.FontAwesomeIcons;
-using Sharpnado.Tabs;
 
 namespace FocusApp.Views
 {
     internal class TimerView : ContentView
     {
+
+        enum Row { TopBar, TimerDisplay, Island, TimerButtons, BottomWhiteSpace }
+        enum Column { LeftTimerButton, TimerAmount, RightTimerButton }
+
         public TimerView()
         {
+            _timerHelper = new TimerHelper();
+
             Content = new Grid
             {
-                BackgroundColor = Colors.PeachPuff,
+                RowDefinitions = GridRowsColumns.Rows.Define(
+                    ( Row.TopBar, GridRowsColumns.Stars(1)           ),
+                    ( Row.TimerDisplay, GridRowsColumns.Stars(2)     ),
+                    ( Row.Island, GridRowsColumns.Stars(3)           ),
+                    ( Row.TimerButtons, GridRowsColumns.Stars(1)     ),
+                    ( Row.BottomWhiteSpace, GridRowsColumns.Stars(1) )
+                    ),
+                ColumnDefinitions = GridRowsColumns.Columns.Define(
+                    (Column.LeftTimerButton, GridRowsColumns.Stars(1)),
+                    (Column.TimerAmount, GridRowsColumns.Stars(2)),
+                    (Column.RightTimerButton, GridRowsColumns.Stars(1))
+                    ),
+                BackgroundColor = Color.FromArgb("BBD0FF"),
                 Children =
                 {
                     new Button
@@ -22,10 +40,23 @@ namespace FocusApp.Views
                         FontSize = 40,
                         BackgroundColor = Colors.Transparent
                     }
+                    .Row(Row.TopBar)
                     .Top()
                     .Left()
                     .Invoke(b => b.Clicked += (sender, e) => { Content = new SettingsView(); }),
-                    
+
+                    new Button
+                    {
+                        Text = SolidIcons.ChevronUp,
+                        BackgroundColor = Colors.Transparent,
+                        TextColor = Colors.Black,
+                        FontSize = 30,
+                    }
+                    .Font(family: nameof(SolidIcons), size: 40)
+                    .End()
+                    .CenterVertical()
+                    .Row(Row.TimerButtons)
+                    .Column(Column.LeftTimerButton),
 
                     new Label
                     {
@@ -34,6 +65,20 @@ namespace FocusApp.Views
                         HorizontalOptions = LayoutOptions.Center,
                         VerticalOptions = LayoutOptions.Center
                     }
+                    .Row(Row.TimerDisplay)
+                    .Column(Column.TimerAmount),
+
+                    new Button
+                    {
+                        Text = SolidIcons.ChevronDown,
+                        BackgroundColor = Colors.Transparent,
+                        TextColor = Colors.Black,
+                    }
+                    .Font(family: nameof(SolidIcons), size: 40)
+                    .Start()
+                    .CenterVertical()
+                    .Row(Row.TimerButtons)
+                    .Column(Column.RightTimerButton),
                 }
             };
         }

--- a/src/FocusApp/Views/TimerView.cs
+++ b/src/FocusApp/Views/TimerView.cs
@@ -61,13 +61,14 @@ namespace FocusApp.Views
 
                     new Label
                     {
-                        Text = "Timer",
+                        BindingContext = _timerHelper,
                         FontSize = 30,
                         HorizontalOptions = LayoutOptions.Center,
                         VerticalOptions = LayoutOptions.Center
                     }
                     .Row(Row.TimerDisplay)
-                    .Column(Column.TimerAmount),
+                    .Column(Column.TimerAmount)
+                    .Bind(Label.TextProperty, getter: static (TimerHelper th) => th.TimerDisplay),
 
                     new Button
                     {


### PR DESCRIPTION
Fixes #27 

### Problem
As a user, I need a timer to help me focus and take breaks

### What was Changed?
- Added a timer to the timer screen that:
    - Allows the user to increase & decrease timer length by clicking or holding down stepper buttons
    - Has a timer that counts down
    - Has a break mode and a focus mode and switches between them
        - The user can stop the focus timer
        - The user can skip the break timer
        - If the user stops their focus timer, they do not move onto break mode, the timer is reset to start another focus session
        - If the user skips their break timer, the timer resets to start focus mode
        - If the user minimizes the app while the timer is running, then comes back, the time outside of the app will be accounted for in the timer
- Added the team-created color palette the the AppStyles
- Added application-wide static events for app lifecycle events


### Documentation
https://github.com/ChrispyPeaches/FocusFriends/wiki/FocusApp-Timer-Feature

### How did you test this?
[Testing criteria detailed in the documentation](https://github.com/ChrispyPeaches/FocusFriends/wiki/FocusApp-Timer-Feature)