### PR TITLE
[Hotfix] FocusContext API db instantiation error

### DIFF
--- a/src/FocusAPI/Program.cs
+++ b/src/FocusAPI/Program.cs
@@ -33,7 +33,10 @@ builder.Services.AddDbContext<FocusContext>(options =>
 var app = builder.Build();
 
 // Instantiate the DbContext so that the database is created if it doesn't exist
-_ = app.Services.GetService<FocusContext>();
+_ = app.Services
+    .CreateScope()
+    .ServiceProvider
+    .GetService<FocusContext>();
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsProduction())


### PR DESCRIPTION
Fixes #57

## Problem
Error when starting the app and instantiating the FocusContext.

## Solution
Find a new method of instantiation

## How was this tested?
- Ran locally
- automated CI build pass