### PR TITLE
Fix Local User Persistence / Fix MindfulnessTip/SessionRating PopupService Issues / Add TryCatches to API calls

### DIFF
--- a/src/FocusAPI/Methods/User/AddUserFurniture.cs
+++ b/src/FocusAPI/Methods/User/AddUserFurniture.cs
@@ -19,11 +19,10 @@ public class AddUserFurniture
             FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
             FocusAPI.Models.Furniture furniture = _context.Furniture.First(f => f.Id == command.FurnitureId);
 
-            _context.UserFurniture.Add(new UserFurniture
+            user.Furniture.Add(new UserFurniture
             {
-                User = user,
                 Furniture = furniture,
-                DateAcquired = DateTime.UtcNow,
+                DateAcquired = DateTime.UtcNow
             });
 
             user.Balance = command.UpdatedBalance;

--- a/src/FocusAPI/Methods/User/AddUserFurniture.cs
+++ b/src/FocusAPI/Methods/User/AddUserFurniture.cs
@@ -9,25 +9,34 @@ public class AddUserFurniture
     public class Handler : IRequestHandler<AddUserFurnitureCommand, Unit>
     {
         FocusContext _context;
-        public Handler(FocusContext context)
+        ILogger<Handler> _logger;
+        public Handler(FocusContext context, ILogger<Handler> logger)
         {
             _context = context;
+            _logger = logger;
         }
 
         public async Task<Unit> Handle(AddUserFurnitureCommand command, CancellationToken cancellationToken)
         {
-            FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-            FocusAPI.Models.Furniture furniture = _context.Furniture.First(f => f.Id == command.FurnitureId);
-
-            user.Furniture.Add(new UserFurniture
+            try
             {
-                Furniture = furniture,
-                DateAcquired = DateTime.UtcNow
-            });
+                FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
+                FocusAPI.Models.Furniture furniture = _context.Furniture.First(f => f.Id == command.FurnitureId);
 
-            user.Balance = command.UpdatedBalance;
+                user.Furniture.Add(new UserFurniture
+                {
+                    Furniture = furniture,
+                    DateAcquired = DateTime.UtcNow
+                });
 
-            await _context.SaveChangesAsync();
+                user.Balance = command.UpdatedBalance;
+
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Error, "Error adding UserFurniture to database. Exception: " + ex.Message);
+            }
 
             return Unit.Value;
         }

--- a/src/FocusAPI/Methods/User/AddUserFurniture.cs
+++ b/src/FocusAPI/Methods/User/AddUserFurniture.cs
@@ -2,6 +2,7 @@
 using FocusAPI.Models;
 using MediatR;
 using FocusAPI.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace FocusApi.Methods.User;
 public class AddUserFurniture
@@ -20,8 +21,8 @@ public class AddUserFurniture
         {
             try
             {
-                FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-                FocusAPI.Models.Furniture furniture = _context.Furniture.First(f => f.Id == command.FurnitureId);
+                FocusAPI.Models.User user = await _context.Users.FirstOrDefaultAsync(u => u.Id == command.UserId);
+                FocusAPI.Models.Furniture furniture = await _context.Furniture.FirstOrDefaultAsync(f => f.Id == command.FurnitureId);
 
                 user.Furniture.Add(new UserFurniture
                 {

--- a/src/FocusAPI/Methods/User/AddUserPet.cs
+++ b/src/FocusAPI/Methods/User/AddUserPet.cs
@@ -2,7 +2,6 @@
 using FocusAPI.Models;
 using MediatR;
 using FocusAPI.Data;
-using FocusCore.Models;
 
 namespace FocusApi.Methods.User;
 public class AddUserPet
@@ -18,13 +17,12 @@ public class AddUserPet
         public async Task<Unit> Handle(AddUserPetCommand command, CancellationToken cancellationToken)
         {
             FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-            FocusAPI.Models.Pet pet = _context.Pets.First(p => p.Id == command.PetId);
+            Pet pet = _context.Pets.First(p => p.Id == command.PetId);
 
-            _context.UserPets.Add(new UserPet
-            { 
-                User = user,
+            user.Pets.Add(new UserPet
+            {
                 Pet = pet,
-                DateAcquired = DateTime.UtcNow,
+                DateAcquired = DateTime.UtcNow
             });
 
             user.Balance = command.UpdatedBalance;

--- a/src/FocusAPI/Methods/User/AddUserPet.cs
+++ b/src/FocusAPI/Methods/User/AddUserPet.cs
@@ -2,6 +2,7 @@
 using FocusAPI.Models;
 using MediatR;
 using FocusAPI.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace FocusApi.Methods.User;
 public class AddUserPet
@@ -20,8 +21,8 @@ public class AddUserPet
         {
             try
             {
-                FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-                Pet pet = _context.Pets.First(p => p.Id == command.PetId);
+                FocusAPI.Models.User user = await _context.Users.FirstOrDefaultAsync(u => u.Id == command.UserId);
+                Pet pet = await _context.Pets.FirstOrDefaultAsync(p => p.Id == command.PetId);
 
                 user.Pets?.Add(new UserPet
                 {

--- a/src/FocusAPI/Methods/User/AddUserPet.cs
+++ b/src/FocusAPI/Methods/User/AddUserPet.cs
@@ -9,26 +9,35 @@ public class AddUserPet
     public class Handler : IRequestHandler<AddUserPetCommand, Unit>
     {
         FocusContext _context;
-        public Handler(FocusContext context)
+        ILogger<Handler> _logger;
+        public Handler(FocusContext context, ILogger<Handler> logger)
         {
             _context = context;
+            _logger = logger;
         }
 
         public async Task<Unit> Handle(AddUserPetCommand command, CancellationToken cancellationToken)
         {
-            FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-            Pet pet = _context.Pets.First(p => p.Id == command.PetId);
-
-            user.Pets.Add(new UserPet
+            try
             {
-                Pet = pet,
-                DateAcquired = DateTime.UtcNow
-            });
+                FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
+                Pet pet = _context.Pets.First(p => p.Id == command.PetId);
 
-            user.Balance = command.UpdatedBalance;
+                user.Pets?.Add(new UserPet
+                {
+                    Pet = pet,
+                    DateAcquired = DateTime.UtcNow
+                });
 
-            await _context.SaveChangesAsync();
+                user.Balance = command.UpdatedBalance;
 
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex) 
+            {
+                _logger.Log(LogLevel.Error, "Error adding UserPet to database. Exception: " + ex.Message);
+            }
+            
             return Unit.Value;
         }
     }

--- a/src/FocusAPI/Methods/User/AddUserSound.cs
+++ b/src/FocusAPI/Methods/User/AddUserSound.cs
@@ -19,11 +19,10 @@ public class AddUserSound
             FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
             FocusAPI.Models.Sound sound = _context.Sounds.First(s => s.Id == command.SoundId);
 
-            _context.UserSounds.Add(new UserSound
+            user.Sounds.Add(new UserSound
             {
-                User = user,
                 Sound = sound,
-                DateAcquired = DateTime.UtcNow,
+                DateAcquired = DateTime.UtcNow
             });
 
             user.Balance = command.UpdatedBalance;

--- a/src/FocusAPI/Methods/User/AddUserSound.cs
+++ b/src/FocusAPI/Methods/User/AddUserSound.cs
@@ -9,25 +9,34 @@ public class AddUserSound
     public class Handler : IRequestHandler<AddUserSoundCommand, Unit>
     {
         FocusContext _context;
-        public Handler(FocusContext context)
+        ILogger<Handler> _logger;
+        public Handler(FocusContext context, ILogger<Handler> logger)
         {
             _context = context;
+            _logger = logger;
         }
 
         public async Task<Unit> Handle(AddUserSoundCommand command, CancellationToken cancellationToken)
         {
-            FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-            FocusAPI.Models.Sound sound = _context.Sounds.First(s => s.Id == command.SoundId);
-
-            user.Sounds.Add(new UserSound
+            try
             {
-                Sound = sound,
-                DateAcquired = DateTime.UtcNow
-            });
+                FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
+                FocusAPI.Models.Sound sound = _context.Sounds.First(s => s.Id == command.SoundId);
 
-            user.Balance = command.UpdatedBalance;
+                user.Sounds.Add(new UserSound
+                {
+                    Sound = sound,
+                    DateAcquired = DateTime.UtcNow
+                });
 
-            await _context.SaveChangesAsync();
+                user.Balance = command.UpdatedBalance;
+
+                await _context.SaveChangesAsync();
+            }
+            catch (Exception ex) 
+            {
+                _logger.Log(LogLevel.Error, "Error adding UserSound to database. Exception: " + ex.Message);
+            }
 
             return Unit.Value;
         }

--- a/src/FocusAPI/Methods/User/AddUserSound.cs
+++ b/src/FocusAPI/Methods/User/AddUserSound.cs
@@ -2,6 +2,7 @@
 using FocusAPI.Models;
 using MediatR;
 using FocusAPI.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace FocusApi.Methods.User;
 public class AddUserSound
@@ -20,8 +21,8 @@ public class AddUserSound
         {
             try
             {
-                FocusAPI.Models.User user = _context.Users.First(u => u.Id == command.UserId);
-                FocusAPI.Models.Sound sound = _context.Sounds.First(s => s.Id == command.SoundId);
+                FocusAPI.Models.User user = await _context.Users.FirstOrDefaultAsync(u => u.Id == command.UserId);
+                FocusAPI.Models.Sound sound = await _context.Sounds.FirstOrDefaultAsync(s => s.Id == command.SoundId);
 
                 user.Sounds.Add(new UserSound
                 {

--- a/src/FocusAPI/Methods/User/GetUser.cs
+++ b/src/FocusAPI/Methods/User/GetUser.cs
@@ -3,6 +3,7 @@ using FocusCore.Models;
 using MediatR;
 using FocusAPI.Data;
 using FocusAPI.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace FocusApi.Methods.User;
 public class GetUser
@@ -30,7 +31,8 @@ public class GetUser
                     Id = Guid.NewGuid(),
                     UserName = query.UserName,
                     Email = query.Email,
-                    Balance = 0
+                    Balance = 0,
+                    DateCreated = DateTime.UtcNow
                 };
 
                 _context.Users.Add((FocusAPI.Models.User) user);

--- a/src/FocusAPI/Models/User.cs
+++ b/src/FocusAPI/Models/User.cs
@@ -10,11 +10,11 @@ public class User : FocusCore.Models.BaseUser
     [InverseProperty(nameof(Friendship.Friend))]
     public new ICollection<Friendship>? Invitees { get; set; }
 
-	public new ICollection<UserPet>? Pets { get; set; }
+    public new ICollection<UserPet>? Pets { get; set; } = new List<UserPet>();
 
-    public new ICollection<UserFurniture>? Furniture { get; set; }
+    public new ICollection<UserFurniture>? Furniture { get; set; } = new List<UserFurniture>();
 
-    public new ICollection<UserSound>? Sounds { get; set; }
+    public new ICollection<UserSound>? Sounds { get; set; } = new List<UserSound>();
 
     public new ICollection<UserBadge>? Badges { get; set; }
 

--- a/src/FocusAPI/appsettings.Development.json
+++ b/src/FocusAPI/appsettings.Development.json
@@ -1,5 +1,5 @@
 {
-    "DefaultConnectionString": "Data Source=localhost;Initial Catalog=FocusFriendsDevTest;Integrated Security=True;Trust Server Certificate=True",
+    "DefaultConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DEV_FocusApiDb;Integrated Security=True;",
     "Logging": {
         "LogLevel": {
             "Default": "Information",

--- a/src/FocusAPI/appsettings.Development.json
+++ b/src/FocusAPI/appsettings.Development.json
@@ -1,9 +1,9 @@
 {
-  "DefaultConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DEV_FocusApiDb;Integrated Security=True;",
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "DefaultConnectionString": "Data Source=localhost;Initial Catalog=FocusFriendsDevTest;Integrated Security=True;Trust Server Certificate=True",
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
     }
-  }
 }

--- a/src/FocusApp.Client/Methods/User/GetUserLogin.cs
+++ b/src/FocusApp.Client/Methods/User/GetUserLogin.cs
@@ -1,0 +1,94 @@
+﻿using System.Security.Claims;
+using Auth0.OidcClient;
+using FocusApp.Client.Clients;
+using FocusApp.Shared.Data;
+using FocusCore.Queries.User;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace FocusApp.Client.Methods.User
+{
+    public class GetUserLogin
+    {
+        public class Query : IRequest<Result> { }
+
+        public class Result
+        { 
+            public string? AuthToken { get; set; }
+            public FocusApp.Shared.Models.User? CurrentUser { get; set; }
+            public bool IsSuccessful { get; set; }
+            public string? ErrorDescription { get; set; }
+        }
+
+        public class Handler : IRequestHandler<Query, Result>
+        {
+            private readonly Auth0Client _auth0Client;
+            IAPIClient _client;
+            FocusAppContext _localContext;
+            ILogger<Handler> _logger;
+            public Handler(Auth0Client auth0Client, IAPIClient client, FocusAppContext localContext, ILogger<Handler> logger)
+            {
+                _auth0Client = auth0Client;
+                _client = client;
+                _localContext = localContext;
+                _logger = logger;
+            }
+
+            public async Task<Result> Handle(Query query, CancellationToken cancellationToken)
+            {
+                var loginResult = await _auth0Client.LoginAsync();
+
+                if (!loginResult.IsError)
+                {
+                    var userIdentity = loginResult.User.Identity as ClaimsIdentity;
+                    if (userIdentity != null)
+                    {
+                        IEnumerable<Claim> claims = userIdentity.Claims;
+
+                        string auth0UserId = claims.First(c => c.Type == "sub").Value;
+                        string userEmail = claims.First(c => c.Type == "email").Value;
+                        string userName = claims.First(c => c.Type == "name").Value;
+
+                        try
+                        {
+                            // Fetch user data from the server
+                            Shared.Models.User user = await _client.GetUserByAuth0Id(new GetUserQuery
+                            {
+                                Auth0Id = auth0UserId,
+                                Email = userEmail,
+                                UserName = userName
+                            });
+
+                            // Add user to the local database if the user doesn't exist in the local database
+                            if (!_localContext.Users.Any(u => u.Id == user.Id))
+                            {
+                                _localContext.Users.Add(user);
+                                await _localContext.SaveChangesAsync();
+                            }
+
+                            return new Result
+                            {
+                                AuthToken = loginResult.AccessToken,
+                                CurrentUser = user,
+                                IsSuccessful = true,
+                                ErrorDescription = null
+                            };
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Log(LogLevel.Error, "Error fetching user from server. Exception: " + ex.Message);
+                        }
+                    }
+                }
+
+                return new Result
+                {
+                    AuthToken = null,
+                    CurrentUser = null,
+                    IsSuccessful = false,
+                    ErrorDescription = loginResult.ErrorDescription
+                };
+            }
+        }
+    }
+}

--- a/src/FocusApp.Client/Views/LoginPage.cs
+++ b/src/FocusApp.Client/Views/LoginPage.cs
@@ -153,7 +153,7 @@ internal class LoginPage : BasePage
                     }
                     catch (Exception ex) 
                     {
-                        _logger.Log(LogLevel.Error, "Error fetching user from server.");
+                        _logger.Log(LogLevel.Error, "Error fetching user from server. Exception: " + ex.Message);
                     }
                 }
 
@@ -166,7 +166,7 @@ internal class LoginPage : BasePage
         }
         catch (Exception ex) 
         {
-            _logger.Log(LogLevel.Error, "Error during login process.");
+            _logger.Log(LogLevel.Error, "Error during login process. Exception: " + ex.Message);
         }
     }
 

--- a/src/FocusApp.Client/Views/LoginPage.cs
+++ b/src/FocusApp.Client/Views/LoginPage.cs
@@ -108,8 +108,8 @@ internal class LoginPage : BasePage
     {
         try
         {
-            // Handle login process
-            GetUserLogin.Result loginResult = await _mediator.Send(new GetUserLogin.Query());
+            // Handle login process on non-UI thread
+            GetUserLogin.Result loginResult = await Task.Run(async () => await _mediator.Send(new GetUserLogin.Query()));
 
             if (loginResult.IsSuccessful)
             {

--- a/src/FocusApp.Client/Views/Mindfulness/MindfulnessTipPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Mindfulness/MindfulnessTipPopupInterface.cs
@@ -54,6 +54,8 @@ namespace FocusApp.Client.Views.Mindfulness
             TipHtmlSource = new HtmlWebViewSource() { Html = "" };
             IsBusy = true;
 
+            CanBeDismissedByTappingOutsideOfPopup = false;
+
             Content = new Border
             {
                 StrokeThickness = 1,

--- a/src/FocusApp.Client/Views/Mindfulness/SessionRatingPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Mindfulness/SessionRatingPopupInterface.cs
@@ -25,6 +25,8 @@ internal class SessionRatingPopupInterface : BasePopup
         VerticalOptions = Microsoft.Maui.Primitives.LayoutAlignment.Center;
         Color = Colors.Transparent;
 
+        CanBeDismissedByTappingOutsideOfPopup = false;
+
         _popupContent = new Grid()
         {
             RowDefinitions = GridRowsColumns.Rows.Define(

--- a/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
@@ -6,6 +6,7 @@ using FocusApp.Client.Resources;
 using FocusApp.Shared.Data;
 using FocusApp.Shared.Models;
 using FocusCore.Commands.User;
+using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Shapes;
 
 namespace FocusApp.Client.Views.Shop
@@ -17,15 +18,17 @@ namespace FocusApp.Client.Views.Shop
         IAuthenticationService _authenticationService;
         IFocusAppContext _localContext;
         IAPIClient _client;
+        ILogger<ShopItemPopupInterface> _logger;
         ShopItem _currentItem { get; set; }
         public ShopPage ShopPage { get; set; }
 
-        public ShopItemPopupInterface(Helpers.PopupService popupService, IAuthenticationService authenticationService, IFocusAppContext localContext, IAPIClient client)
+        public ShopItemPopupInterface(Helpers.PopupService popupService, IAuthenticationService authenticationService, IFocusAppContext localContext, IAPIClient client, ILogger<ShopItemPopupInterface> logger)
         {
             _popupService = popupService;
             _authenticationService = authenticationService;
             _localContext = localContext;
             _client = client;
+            _logger = logger;
 
             // Set popup location
             HorizontalOptions = Microsoft.Maui.Primitives.LayoutAlignment.Center;
@@ -195,7 +198,10 @@ namespace FocusApp.Client.Views.Shop
                             UpdatedBalance = _authenticationService.CurrentUser.Balance,
                         });
                     }
-                    catch (Exception ex) { }
+                    catch (Exception ex) 
+                    {
+                        _logger.Log(LogLevel.Error, "Error adding UserPet to server database. Exception: " + ex.Message);
+                    }
 
                     break;
 
@@ -236,7 +242,10 @@ namespace FocusApp.Client.Views.Shop
                             UpdatedBalance = _authenticationService.CurrentUser.Balance,
                         });
                     }
-                    catch (Exception ex) { }
+                    catch (Exception ex)
+                    {
+                        _logger.Log(LogLevel.Error, "Error adding UserFurniture to server database. Exception: " + ex.Message);
+                    }
 
                     break;
 
@@ -278,7 +287,10 @@ namespace FocusApp.Client.Views.Shop
                             UpdatedBalance = _authenticationService.CurrentUser.Balance,
                         });
                     }
-                    catch (Exception ex) { }
+                    catch (Exception ex)
+                    {
+                        _logger.Log(LogLevel.Error, "Error adding UserSound to server database. Exception: " + ex.Message);
+                    }
 
                     break;
                 default:

--- a/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
@@ -6,6 +6,7 @@ using FocusApp.Client.Resources;
 using FocusApp.Shared.Data;
 using FocusApp.Shared.Models;
 using FocusCore.Commands.User;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Controls.Shapes;
 
@@ -177,15 +178,22 @@ namespace FocusApp.Client.Views.Shop
                         await _localContext.SaveChangesAsync();
                     }
 
-                    // Add the user's new pet to the local database
-                    User user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-                    user.Pets?.Add(new UserPet 
-                    { 
-                        Pet = _localContext.Pets.First(p => p.Id == _currentItem.Id)
-                    });
+                    try
+                    {
+                        // Add the user's new pet to the local database
+                        User user = await _localContext.Users.FirstOrDefaultAsync(u => u.Id == _authenticationService.CurrentUser.Id);
+                        user.Pets?.Add(new UserPet
+                        {
+                            Pet = _localContext.Pets.First(p => p.Id == _currentItem.Id)
+                        });
 
-                    // Update the user's balance on the local database
-                    user.Balance = _authenticationService.CurrentUser.Balance;
+                        // Update the user's balance on the local database
+                        user.Balance = _authenticationService.CurrentUser.Balance;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Log(LogLevel.Error, "Error adding UserPet to local database. Exception: " + ex.Message);
+                    }
 
                     // Add the user's pet to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
@@ -222,14 +230,21 @@ namespace FocusApp.Client.Views.Shop
                     }
 
                     // Add the user's new furniture to the local database
-                    user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-                    user.Furniture?.Add(new UserFurniture
+                    try
                     {
-                        Furniture = _localContext.Furniture.First(f => f.Id == _currentItem.Id)
-                    });
+                        User user = await _localContext.Users.FirstOrDefaultAsync(u => u.Id == _authenticationService.CurrentUser.Id);
+                        user.Furniture?.Add(new UserFurniture
+                        {
+                            Furniture = _localContext.Furniture.First(f => f.Id == _currentItem.Id)
+                        });
 
-                    // Update the user's balance on the local database
-                    user.Balance = _authenticationService.CurrentUser.Balance;
+                        // Update the user's balance on the local database
+                        user.Balance = _authenticationService.CurrentUser.Balance;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Log(LogLevel.Error, "Error adding UserFurniture to local database. Exception: " + ex.Message);
+                    }
 
                     // Add the user's furniture to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
@@ -265,15 +280,22 @@ namespace FocusApp.Client.Views.Shop
                         await _localContext.SaveChangesAsync();
                     }
 
-                    // Add the user's new sound to the local database
-                    user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-                    user.Sounds?.Add(new UserSound
+                    try
                     {
-                        Sound = _localContext.Sounds.First(f => f.Id == _currentItem.Id)
-                    });
+                        // Add the user's new sound to the local database
+                        User user = await _localContext.Users.FirstOrDefaultAsync(u => u.Id == _authenticationService.CurrentUser.Id);
+                        user.Sounds?.Add(new UserSound
+                        {
+                            Sound = _localContext.Sounds.First(f => f.Id == _currentItem.Id)
+                        });
 
-                    // Update the user's balance on the local database
-                    user.Balance = _authenticationService.CurrentUser.Balance;
+                        // Update the user's balance on the local database
+                        user.Balance = _authenticationService.CurrentUser.Balance;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Log(LogLevel.Error, "Error adding UserSound to local database. Exception: " + ex.Message);
+                    }
 
                     // Add the user's sound to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
@@ -297,7 +319,14 @@ namespace FocusApp.Client.Views.Shop
                     break;
             }
 
-            await _localContext.SaveChangesAsync();
+            try
+            {
+                await _localContext.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.Log(LogLevel.Error, "Error saving changes to local database. Exception: " + ex.Message);
+            }
 
             // After purchasing item, update the user balance display on the shop page
             ShopPage._balanceLabel.Text = _authenticationService.CurrentUser.Balance.ToString();

--- a/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
@@ -155,8 +155,6 @@ namespace FocusApp.Client.Views.Shop
         {
             _authenticationService.CurrentUser.Balance -= _currentItem.Price;
 
-            //User currentUser = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-            //User currentUser;
 
             switch (_currentItem.Type)
             {
@@ -179,11 +177,13 @@ namespace FocusApp.Client.Views.Shop
 
                     // Add the user's new pet to the local database
                     User user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-
-                    user.Pets.Add(new UserPet 
+                    user.Pets?.Add(new UserPet 
                     { 
                         Pet = _localContext.Pets.First(p => p.Id == _currentItem.Id)
                     });
+
+                    // Update the user's balance on the local database
+                    user.Balance = _authenticationService.CurrentUser.Balance;
 
                     // Add the user's pet to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
@@ -214,11 +214,13 @@ namespace FocusApp.Client.Views.Shop
 
                     // Add the user's new furniture to the local database
                     user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-
-                    user.Furniture.Add(new UserFurniture
+                    user.Furniture?.Add(new UserFurniture
                     {
                         Furniture = _localContext.Furniture.First(f => f.Id == _currentItem.Id)
                     });
+
+                    // Update the user's balance on the local database
+                    user.Balance = _authenticationService.CurrentUser.Balance;
 
                     // Add the user's furniture to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
@@ -249,11 +251,13 @@ namespace FocusApp.Client.Views.Shop
 
                     // Add the user's new sound to the local database
                     user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
-
-                    user.Sounds.Add(new UserSound
+                    user.Sounds?.Add(new UserSound
                     {
                         Sound = _localContext.Sounds.First(f => f.Id == _currentItem.Id)
                     });
+
+                    // Update the user's balance on the local database
+                    user.Balance = _authenticationService.CurrentUser.Balance;
 
                     // Add the user's sound to the server database
                     // Note: This endpoint additionally updates the user's balance on the server

--- a/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
@@ -32,6 +32,8 @@ namespace FocusApp.Client.Views.Shop
             VerticalOptions = Microsoft.Maui.Primitives.LayoutAlignment.Center;
             Color = Colors.Transparent;
 
+            CanBeDismissedByTappingOutsideOfPopup = false;
+
             _popupContentStack = new StackLayout();
 
             Content = new Border
@@ -153,12 +155,14 @@ namespace FocusApp.Client.Views.Shop
         {
             _authenticationService.CurrentUser.Balance -= _currentItem.Price;
 
+            //User currentUser = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
+            //User currentUser;
+
             switch (_currentItem.Type)
             {
                 case ShopItemType.Pets:
 
                     // If the local database currently does not have the pet, store it now
-
                     // Note: This check will be made obsolete after the shop item sync update
                     if (!_localContext.Pets.Any(p => p.Id == _currentItem.Id))
                     {
@@ -172,11 +176,12 @@ namespace FocusApp.Client.Views.Shop
 
                         await _localContext.SaveChangesAsync();
                     }
-                    
+
                     // Add the user's new pet to the local database
-                    _localContext.UserPets.Add(new UserPet
-                    {
-                        User = (User)_authenticationService.CurrentUser,
+                    User user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
+
+                    user.Pets.Add(new UserPet 
+                    { 
                         Pet = _localContext.Pets.First(p => p.Id == _currentItem.Id)
                     });
 
@@ -208,9 +213,10 @@ namespace FocusApp.Client.Views.Shop
                     }
 
                     // Add the user's new furniture to the local database
-                    _localContext.UserFurniture.Add(new UserFurniture
+                    user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
+
+                    user.Furniture.Add(new UserFurniture
                     {
-                        User = (User)_authenticationService.CurrentUser,
                         Furniture = _localContext.Furniture.First(f => f.Id == _currentItem.Id)
                     });
 
@@ -242,10 +248,11 @@ namespace FocusApp.Client.Views.Shop
                     }
 
                     // Add the user's new sound to the local database
-                    _localContext.UserSounds.Add(new UserSound
+                    user = _localContext.Users.First(u => u.Id == _authenticationService.CurrentUser.Id);
+
+                    user.Sounds.Add(new UserSound
                     {
-                        User = (User)_authenticationService.CurrentUser,
-                        Sound = _localContext.Sounds.First(s => s.Id == _currentItem.Id)
+                        Sound = _localContext.Sounds.First(f => f.Id == _currentItem.Id)
                     });
 
                     // Add the user's sound to the server database

--- a/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
+++ b/src/FocusApp.Client/Views/Shop/ShopItemPopupInterface.cs
@@ -155,7 +155,6 @@ namespace FocusApp.Client.Views.Shop
         {
             _authenticationService.CurrentUser.Balance -= _currentItem.Price;
 
-
             switch (_currentItem.Type)
             {
                 case ShopItemType.Pets:
@@ -187,12 +186,16 @@ namespace FocusApp.Client.Views.Shop
 
                     // Add the user's pet to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
-                    await _client.AddUserPet(new AddUserPetCommand
-                    { 
-                        UserId = _authenticationService.CurrentUser.Id,
-                        PetId = _currentItem.Id,
-                        UpdatedBalance = _authenticationService.CurrentUser.Balance,
-                    });
+                    try
+                    {
+                        await _client.AddUserPet(new AddUserPetCommand
+                        {
+                            UserId = _authenticationService.CurrentUser.Id,
+                            PetId = _currentItem.Id,
+                            UpdatedBalance = _authenticationService.CurrentUser.Balance,
+                        });
+                    }
+                    catch (Exception ex) { }
 
                     break;
 
@@ -224,12 +227,16 @@ namespace FocusApp.Client.Views.Shop
 
                     // Add the user's furniture to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
-                    await _client.AddUserFurniture(new AddUserFurnitureCommand
+                    try
                     {
-                        UserId = _authenticationService.CurrentUser.Id,
-                        FurnitureId = _currentItem.Id,
-                        UpdatedBalance = _authenticationService.CurrentUser.Balance,
-                    });
+                        await _client.AddUserFurniture(new AddUserFurnitureCommand
+                        {
+                            UserId = _authenticationService.CurrentUser.Id,
+                            FurnitureId = _currentItem.Id,
+                            UpdatedBalance = _authenticationService.CurrentUser.Balance,
+                        });
+                    }
+                    catch (Exception ex) { }
 
                     break;
 
@@ -262,12 +269,16 @@ namespace FocusApp.Client.Views.Shop
                     // Add the user's sound to the server database
                     // Note: This endpoint additionally updates the user's balance on the server
                     // If time allows, we will store the sound files on the server, and fetch/store them after purchase
-                    await _client.AddUserSound(new AddUserSoundCommand
+                    try
                     {
-                        UserId = _authenticationService.CurrentUser.Id,
-                        SoundId = _currentItem.Id,
-                        UpdatedBalance = _authenticationService.CurrentUser.Balance,
-                    });
+                        await _client.AddUserSound(new AddUserSoundCommand
+                        {
+                            UserId = _authenticationService.CurrentUser.Id,
+                            SoundId = _currentItem.Id,
+                            UpdatedBalance = _authenticationService.CurrentUser.Balance,
+                        });
+                    }
+                    catch (Exception ex) { }
 
                     break;
                 default:

--- a/src/FocusApp.Shared/Models/User.cs
+++ b/src/FocusApp.Shared/Models/User.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using FocusCore.Models;
 
 namespace FocusApp.Shared.Models;
 
@@ -12,11 +13,11 @@ public class User : FocusCore.Models.BaseUser
     [InverseProperty(nameof(Friendship.Friend))]
     public new ICollection<Friendship>? Invitees { get; set; }
 
-	public new ICollection<UserPet>? Pets { get; set; }
+	public new ICollection<UserPet>? Pets { get; set; } = new List<UserPet>();
 
-    public new ICollection<UserFurniture>? Furniture { get; set; }
+    public new ICollection<UserFurniture>? Furniture { get; set; } = new List<UserFurniture>();
 
-    public new ICollection<UserSound>? Sounds { get; set; }
+    public new ICollection<UserSound>? Sounds { get; set; } = new List<UserSound>();
 
     public new ICollection<UserBadge>? Badges { get; set; }
 

--- a/src/FocusCore/Models/BaseUser.cs
+++ b/src/FocusCore/Models/BaseUser.cs
@@ -38,11 +38,11 @@ public abstract class BaseUser
 
 	public ICollection<BaseFriendship>? Invitees { get; set; }
 
-	public ICollection<BaseUserPet>? Pets { get; set; }
+    public ICollection<BaseUserPet>? Pets { get; set; } = new List<BaseUserPet>();
 
-    public ICollection<BaseUserFurniture>? Furniture { get; set; }
+    public ICollection<BaseUserFurniture>? Furniture { get; set; } = new List<BaseUserFurniture>();
 
-    public ICollection<BaseUserSound>? Sounds { get; set; }
+    public ICollection<BaseUserSound>? Sounds { get; set; } = new List<BaseUserSound>();
 
     public ICollection<BaseUserBadge>? Badges { get; set; }
 


### PR DESCRIPTION
Fixes #85 

## Problem
- User was not being added to local database if nonexistent on startup
- UserPets not being added to the local database optimally
- App would crash if API calls failed
- Add logging for when API calls fail
- Popups were being disposed outside of the PopupService stack, resulting in app crash when popup attempted to be accessed

### Definition of Done
- User is added to local database on sign in if not already there
- App no longer crashes when popup service attempts to access disposed popup
- Make app more reliable
- Make app give helpful logs

## Solution
- User is added to local database on sign in if not already there
- User pets added to local database via user instance (no longer direct insert into UserPets table)
- Added try/catches around API calls
- Added logger to login page and shop popups for when API calls fail
- Prevented users from dismissing popups via clicking out of them

## How was this tested?
Manually