### PR TITLE
Integrate user sessions into storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Focus Friends is a mobile app that uses a timer to track and record user focus s
 ### Useful Links
 [Github Project Task Board](https://github.com/users/ChrispyPeaches/projects/1)
 
-[Sprint planning spreadsheet](https://docs.google.com/spreadsheets/d/1yJxfEH3qCUB0c4kXND5IroIexPQezzHdEeYYtUN7NIc/edit?usp=sharing)
+[Sprint planning spreadsheet](https://docs.google.com/spreadsheets/d/17KuePYD55K4Jvs0dNnzJrx7JADw_CWJ8gCb0m-1L0Fg/edit?usp=sharing)
 
 [Visual Mockup](https://www.figma.com/file/HG8eqMzI47otQWYFIv5iK7/Focus-Timer-App-MockUp?type=design&node-id=0%3A1&mode=design&t=gdzpRvpkRlAWQJPb-1)
 

--- a/src/FocusAPI/Controllers/UserController.cs
+++ b/src/FocusAPI/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using FocusAPI.Methods.User;
 using Microsoft.AspNetCore.Mvc;
 using MediatR;
 using FocusCore.Commands.User;
@@ -92,6 +93,44 @@ namespace FocusAPI.Controllers
                     return StatusCode((int)result.HttpStatusCode);
             }
         }
+
+        /// <summary>
+        /// Feature: <see cref="Methods.User.AddSessionToUser"/>
+        /// </summary>
+        [HttpPost]
+        [Route("AddSession")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> AddSessionToUser(
+            [FromBody] CreateSessionCommand query,
+            CancellationToken cancellationToken = default)
+        {
+            MediatrResult result = new();
+
+            try
+            {
+                result = await _mediator.Send(query, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[500]: Error getting user");
+                return StatusCode((int)HttpStatusCode.InternalServerError);
+            }
+
+            switch (result.HttpStatusCode)
+            {
+                case null:
+                    _logger.LogError($"[500] {result.Message}");
+                    return StatusCode((int)HttpStatusCode.InternalServerError);
+                case HttpStatusCode.OK:
+                    return Ok();
+                default:
+                    _logger.LogError($"[{(int)result.HttpStatusCode}] {result.Message}");
+                    return StatusCode((int)result.HttpStatusCode);
+            }
+        }
+
 
         [HttpPost]
         [Route("Pet")]

--- a/src/FocusAPI/Methods/User/AddSessionToUser.cs
+++ b/src/FocusAPI/Methods/User/AddSessionToUser.cs
@@ -1,0 +1,91 @@
+﻿using System.Net;
+using FocusCore.Commands.User;
+using MediatR;
+using FocusAPI.Data;
+using FocusAPI.Models;
+using Microsoft.EntityFrameworkCore;
+using FocusCore.Responses;
+
+namespace FocusAPI.Methods.User;
+public class AddSessionToUser
+{
+    public class Handler : IRequestHandler<CreateSessionCommand, MediatrResult>
+    {
+        private readonly FocusContext _context;
+
+        public Handler(
+            FocusContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<MediatrResult> Handle(
+            CreateSessionCommand command,
+            CancellationToken cancellationToken = default)
+        {
+            FocusAPI.Models.User? user = await GetUser(command.Auth0Id, cancellationToken);
+               
+            // If the user exists, add the session to their sessions
+            if (user != null)
+            {
+                await AddSessionToUser(command, user, cancellationToken);
+
+                return new MediatrResult { HttpStatusCode = HttpStatusCode.OK };
+            }
+            else
+            {
+                return new MediatrResult
+                { 
+                    HttpStatusCode = HttpStatusCode.NotFound, 
+                    Message = $"User not found with Auth0Id: {command.Auth0Id}",
+                };
+            }
+        }
+
+        private async Task<FocusAPI.Models.User?> GetUser(
+            string? auth0Id,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _context.Users
+                    .Include(u => u.UserSessions)
+                    .Where(u => u.Auth0Id == auth0Id)
+                    .FirstOrDefaultAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error getting user", ex);
+            }
+        }
+
+        private async Task AddSessionToUser(
+            CreateSessionCommand command,
+            Models.User? user,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                UserSession session = new UserSession()
+                {
+                    Id = command.SessionId,
+                    SessionStartTime = command.SessionStartTime,
+                    SessionEndTime = command.SessionEndTime,
+                    CurrencyEarned = command.CurrencyEarned,
+                    User = user,
+                    UserId = user.Id
+                };
+
+                await _context.UserSessionHistory.AddAsync(session, cancellationToken);
+
+                user?.UserSessions?.Add(session);
+
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error adding session to user.", ex);
+            }
+        }
+    }
+}

--- a/src/FocusApp.Client/Clients/IAPIClient.cs
+++ b/src/FocusApp.Client/Clients/IAPIClient.cs
@@ -31,6 +31,11 @@ public interface IAPIClient
     [Post("/User/Sound")]
     Task AddUserSound(AddUserSoundCommand command);
 
+    [Post("/User/AddSession")]
+    Task CreateSession(
+        CreateSessionCommand command,
+        CancellationToken cancellationToken = default);
+
     #endregion
 
     #region Shop

--- a/src/FocusApp.Client/Helpers/AuthenticationService.cs
+++ b/src/FocusApp.Client/Helpers/AuthenticationService.cs
@@ -1,15 +1,14 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using CommunityToolkit.Mvvm.ComponentModel;
 using FocusApp.Shared.Models;
 
 namespace FocusApp.Client.Helpers;
 
 internal interface IAuthenticationService
 {
-    string Id { get; set; }
-    string Email { get; set; }
-    string AuthToken { get; set; }
+    string? Auth0Id { get; set; }
+    string? Email { get; set; }
+    string? AuthToken { get; set; }
     User? CurrentUser { get; set; }
     Island? SelectedIsland { get; set; }
     Pet? SelectedPet { get; set; }
@@ -22,9 +21,9 @@ internal interface IAuthenticationService
 public class AuthenticationService : INotifyPropertyChanged, IAuthenticationService
 {
     public event PropertyChangedEventHandler? PropertyChanged;
-    public string Id { get; set; } = "";
-    public string Email { get; set; } = "";
-    public string AuthToken { get; set; } = "";
+    public string? Auth0Id { get; set; } = "";
+    public string? Email { get; set; } = "";
+    public string? AuthToken { get; set; } = "";
 
     private User? _currentUser;
     public User? CurrentUser

--- a/src/FocusApp.Client/Methods/User/AddSessionToUser.cs
+++ b/src/FocusApp.Client/Methods/User/AddSessionToUser.cs
@@ -104,7 +104,7 @@ internal class AddSessionToUser
                     SessionId = sessionId,
                     SessionStartTime = query.SessionStartTime,
                     SessionEndTime = query.SessionEndTime,
-                    CurrencyEarned = query.CurrencyEarned
+                    CurrencyEarned = currencyEarned
                 }, cancellationToken);
             }
             catch (Exception ex)

--- a/src/FocusApp.Client/Methods/User/AddSessionToUser.cs
+++ b/src/FocusApp.Client/Methods/User/AddSessionToUser.cs
@@ -1,0 +1,144 @@
+﻿using FocusApp.Client.Clients;
+using FocusApp.Client.Helpers;
+using FocusApp.Shared.Data;
+using FocusCore.Commands.User;
+using FocusApp.Shared.Models;
+using Microsoft.EntityFrameworkCore;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace FocusApp.Client.Methods.User;
+internal class AddSessionToUser
+{
+    public class Query : IRequest
+    {
+        public DateTimeOffset SessionStartTime { get; set; }
+        public DateTimeOffset SessionEndTime { get; set; }
+        public int CurrencyEarned { get; set; }
+    }
+
+    public class Handler : IRequestHandler<Query>
+    {
+        private readonly FocusAppContext _context;
+        private readonly IAuthenticationService _authService;
+        private readonly ILogger<Handler> _logger;
+        private readonly IAPIClient _client;
+
+        public Handler(
+            FocusAppContext context,
+            IAuthenticationService authService,
+            ILogger<Handler> logger,
+            IAPIClient client)
+        {
+            _context = context;
+            _authService = authService;
+            _logger = logger;
+            _client = client;
+        }
+
+        public async Task Handle(
+            Query query,
+            CancellationToken cancellationToken = default)
+        {
+            // If a user isn't logged in, don't track the session
+            if (_authService?.Auth0Id is null) return;
+
+            Shared.Models.User? user = await GetUser(cancellationToken);
+
+            UserSession session = CreateSession(query, user);
+
+            // If a user isn't found, don't track the session
+            if (user is null) return;
+
+            await AddSessionToServerUser(
+                query,
+                session.Id,
+                _authService.Auth0Id,
+                session.CurrencyEarned,
+                cancellationToken);
+
+            await AddSessionToMobileDatabaseUser(session, user, cancellationToken);
+        }
+
+        private async Task<Shared.Models.User?> GetUser(
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _context.Users
+                    .Include(u => u.UserSessions)
+                    .Where(u => u.Auth0Id == _authService.Auth0Id)
+                    .FirstOrDefaultAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error getting user", ex);
+            }
+        }
+
+        private static UserSession CreateSession(
+            Query query,
+            Shared.Models.User user) =>
+            new()
+            {
+                Id = Guid.NewGuid(),
+                SessionStartTime = query.SessionStartTime.UtcDateTime,
+                SessionEndTime = query.SessionEndTime.UtcDateTime,
+                CurrencyEarned = CalculateCurrencyEarned(query),
+                User = user,
+                UserId = user.Id
+            };
+
+        private async Task AddSessionToServerUser(
+            Query query,
+            Guid sessionId,
+            string auth0Id,
+            int currencyEarned,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _client.CreateSession(new CreateSessionCommand()
+                {
+                    Auth0Id = auth0Id,
+                    SessionId = sessionId,
+                    SessionStartTime = query.SessionStartTime,
+                    SessionEndTime = query.SessionEndTime,
+                    CurrencyEarned = query.CurrencyEarned
+                }, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Error adding session to user on server.");
+            }
+        }
+
+        private async Task AddSessionToMobileDatabaseUser(
+            UserSession session,
+            Shared.Models.User user,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _context.AddAsync(session, cancellationToken);
+                user.UserSessions?.Add(session);
+
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Error adding session to user in mobile database.");
+            }
+        }
+
+        private static int CalculateCurrencyEarned(Query query)
+        {
+            int currencyEarned = (int)Math.Ceiling((query.SessionEndTime - query.SessionStartTime).TotalMinutes);
+
+            // Ensure the value is not negative
+            currencyEarned = currencyEarned <= 0 ? 0 : currencyEarned;
+
+            return currencyEarned;
+        }
+    }
+}

--- a/src/FocusApp.Client/Views/LoginPage.cs
+++ b/src/FocusApp.Client/Views/LoginPage.cs
@@ -126,6 +126,7 @@ internal class LoginPage : BasePage
 
             if (loginResult.IsSuccessful)
             {
+                _authenticationService.Auth0Id = loginResult.CurrentUser?.Auth0Id;
                 _authenticationService.AuthToken = loginResult.AuthToken;
                 _authenticationService.CurrentUser = loginResult.CurrentUser;
 

--- a/src/FocusCore/Commands/User/CreateSessionCommand.cs
+++ b/src/FocusCore/Commands/User/CreateSessionCommand.cs
@@ -1,0 +1,13 @@
+﻿using FocusCore.Responses;
+using MediatR;
+
+namespace FocusCore.Commands.User;
+
+public class CreateSessionCommand : IRequest<MediatrResult>
+{
+    public string? Auth0Id { get; set; }
+    public Guid SessionId { get; set; }
+    public DateTimeOffset SessionStartTime { get; set; }
+    public DateTimeOffset SessionEndTime { get; set; }
+    public int CurrencyEarned { get; set; }
+}

--- a/src/FocusCore/Responses/MediatrResult.cs
+++ b/src/FocusCore/Responses/MediatrResult.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace FocusCore.Responses;
+
+public class MediatrResult
+{
+    public HttpStatusCode? HttpStatusCode { get; set; }
+    public string? Message { get; set; }
+}


### PR DESCRIPTION
Fixes #65 

## Problem
After timer session is completed, the session is not recorded under the currently logged in user.

### Definition of Done
After a timer session, the UserSessions table on the local database and the server database are updated accordingly.

## Solution
- Add endpoint on API for adding session to user with MediatR feature
- Add MediatR feature on App for creating session locally and sending it to the client
  - Integrate with the timer service to run after a focus session is completed

## Documentation
- [Added small section to timer docs about user session storage and a section about currency earned rate](https://github.com/ChrispyPeaches/FocusFriends/wiki/FocusApp-Timer-Feature/_edit#user-session-tracking)
- Updated readme to have new spring planning spreadsheet link

## How was this tested?
- Completed a focus session without being logged in and verified there were no errors and nothing was saved
- Completed a focus session while being logged in and verified the sessions were saved to the local db and the api database
- Verified that the currency earned was updated in the databases