### PR TITLE
[Hotfix] Add initial items to user relation item tables on user creation

### DIFF
--- a/src/FocusAPI/Methods/User/CreateUser.cs
+++ b/src/FocusAPI/Methods/User/CreateUser.cs
@@ -4,7 +4,6 @@ using MediatR;
 using FocusAPI.Data;
 using FocusAPI.Helpers;
 using FocusAPI.Models;
-using FocusCore.Models;
 using FocusCore.Responses.User;
 using Microsoft.EntityFrameworkCore;
 using FocusCore.Responses;
@@ -129,13 +128,21 @@ public class CreateUser
 
             if (initialPet != null)
             {
-                user.Pets?.Add(new UserPet() { Pet = initialPet });
+                user.Pets?.Add(new UserPet()
+                {
+                    DateAcquired = DateTimeOffset.UtcNow,
+                    Pet = initialPet
+                });
                 user.SelectedPet = initialPet;
             }
 
             if (initialIsland != null)
             {
-                user.Islands?.Add(new UserIsland() { Island = initialIsland });
+                user.Islands?.Add(new UserIsland()
+                {
+                    DateAcquired = DateTimeOffset.UtcNow,
+                    Island = initialIsland
+                });
                 user.SelectedIsland = initialIsland;
             }
 

--- a/src/FocusApp.Client/Methods/User/GetUserLogin.cs
+++ b/src/FocusApp.Client/Methods/User/GetUserLogin.cs
@@ -172,9 +172,19 @@ namespace FocusApp.Client.Methods.User
 
                 user.SelectedIsland = await GetInitialIslandQuery()
                     .FirstOrDefaultAsync(cancellationToken);
+                user.Islands?.Add(new UserIsland()
+                {
+                    DateAcquired = DateTime.UtcNow,
+                    Island = user.SelectedIsland
+                });
 
                 user.SelectedPet = await GetInitialPetQuery()
                     .FirstOrDefaultAsync(cancellationToken);
+                user.Pets?.Add(new UserPet()
+                {
+                    DateAcquired = DateTime.UtcNow,
+                    Pet = user.SelectedPet
+                });
 
                 return user;
             }


### PR DESCRIPTION
[HOTFIX]

## Problem
The pets page wasn't showing the cool cat as a selectable pet because the user didn't receive the pet as a userpet when the user was created

### Definition of Done
- The initial island is added to a new user's UserIslands
- The initial pet is added to a new user's UserPets

## Solution
- Add these initial items to the user's user item relation tables when the user is created 

## How was this tested?
- Created a new user and verified when going to the pets page that cool cat was shown and selected
- Checked the API database to verify the userpet and userisland entries existed for the new user with the initial items