### PR TITLE
[Hotfix] Added check for null selected checkmark

### DIFF
--- a/src/FocusApp.Client/Views/Social/PetsPage.cs
+++ b/src/FocusApp.Client/Views/Social/PetsPage.cs
@@ -299,7 +299,12 @@ internal sealed class PetsPage : BasePage
         // On success, hide previous checkmark and show new one
         if (result.Success)
         {
-            _selectedCheckmark.Opacity = 0.0;
+            // In case selected checkmark is null
+            if (_selectedCheckmark != null)
+            {
+                _selectedCheckmark.Opacity = 0.0;
+            }
+
             _selectedCheckmark = checkmark;
             _selectedCheckmark.Opacity = 1.0;
 


### PR DESCRIPTION
Hotfix #72 

## Problem
App crashes if the user has no selected pet causing a null error as there is no image preassigned to the selected checkmark.

## Solution
Added a null check to the selected checkmark image before reassigning it.