### PR TITLE
[HOTFIX] User profile selected item fixes / Adjust styling / Connect selected item buttons to correct pages

### DIFF
--- a/src/FocusApp.Client/Helpers/PopupService.cs
+++ b/src/FocusApp.Client/Helpers/PopupService.cs
@@ -86,6 +86,23 @@ namespace FocusApp.Client.Helpers
             }
         }
 
+        public void HidePopup<T>(bool wasDismissedByTappingOutsideOfPopup = false) where T : BasePopup
+        {
+            if (_popups.Count > 0)
+            {
+                if (typeof(T) == _popups.Peek().GetType())
+                {
+                    // Quick patch for popups closed via tapping outside of the popup
+                    if (wasDismissedByTappingOutsideOfPopup)
+                        // Remove the popup from the stack, but do not close it, as it has already
+                        // been closed/disposed via tapping outside of popup
+                        _popups.Pop();
+                    else
+                        MainThread.BeginInvokeOnMainThread(() => _popups.Pop().Close());
+                }
+            }
+        }
+
         public async Task HidePopupAsync(bool wasDismissedByTappingOutsideOfPopup = false)
         {
             if (_popups.Count > 0)
@@ -97,6 +114,23 @@ namespace FocusApp.Client.Helpers
                     _popups.Pop();
                 else
                     await MainThread.InvokeOnMainThreadAsync(() => _popups.Pop().Close());
+            }
+        }
+
+        public async Task HidePopupAsync<T>(bool wasDismissedByTappingOutsideOfPopup = false) where T : BasePopup
+        {
+            if (_popups.Count > 0)
+            {
+                if (typeof(T) == _popups.Peek().GetType())
+                {
+                    // Quick patch for popups closed via tapping outside of the popup
+                    if (wasDismissedByTappingOutsideOfPopup)
+                        // Remove the popup from the stack, but do not close it, as it has already
+                        // been closed/disposed via tapping outside of popup
+                        _popups.Pop();
+                    else
+                        await MainThread.InvokeOnMainThreadAsync(() => _popups.Pop().Close());
+                }
             }
         }
 

--- a/src/FocusApp.Client/Helpers/PopupService.cs
+++ b/src/FocusApp.Client/Helpers/PopupService.cs
@@ -38,6 +38,19 @@ namespace FocusApp.Client.Helpers
         }
 
         /// <summary>
+        /// Show popup.
+        /// </summary>
+        /// <typeparam name="T">Popup</typeparam>
+        /// <exception cref="MissingMethodException"></exception>
+        public async Task ShowPopupAsync<T>() where T : Popup
+        {
+            var mainPage = App.Current?.MainPage ?? throw new MissingMethodException("Main page is null");
+            var popup = _services.GetRequiredService<T>();
+            await MainThread.InvokeOnMainThreadAsync(() => mainPage.ShowPopup<T>(popup));
+            _popups.Push(popup);
+        }
+
+        /// <summary>
         /// Show popup and return the object for populating with shop data
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -70,6 +83,20 @@ namespace FocusApp.Client.Helpers
                     _popups.Pop();
                 else
                     MainThread.BeginInvokeOnMainThread(() => _popups.Pop().Close());
+            }
+        }
+
+        public async Task HidePopupAsync(bool wasDismissedByTappingOutsideOfPopup = false)
+        {
+            if (_popups.Count > 0)
+            {
+                // Quick patch for popups closed via tapping outside of the popup
+                if (wasDismissedByTappingOutsideOfPopup)
+                    // Remove the popup from the stack, but do not close it, as it has already
+                    // been closed/disposed via tapping outside of popup
+                    _popups.Pop();
+                else
+                    await MainThread.InvokeOnMainThreadAsync(() => _popups.Pop().Close());
             }
         }
 

--- a/src/FocusApp.Client/Methods/User/GetUserLogin.cs
+++ b/src/FocusApp.Client/Methods/User/GetUserLogin.cs
@@ -145,7 +145,7 @@ namespace FocusApp.Client.Methods.User
                 user = await GatherUserDataForCreatedUser(createUserResponse, auth0UserId, userEmail, userName, cancellationToken);
 
                 bool userExistsLocally = await _localContext.Users
-                    .AnyAsync(u => u.Auth0Id == auth0UserId, cancellationToken);
+                    .AnyAsync(u => u.Auth0Id == auth0UserId || u.Id == user.Id, cancellationToken);
 
                 // Add user to the local database if the user doesn't exist locally
                 if (!userExistsLocally)

--- a/src/FocusApp.Client/Methods/User/GetUserLogin.cs
+++ b/src/FocusApp.Client/Methods/User/GetUserLogin.cs
@@ -250,7 +250,7 @@ namespace FocusApp.Client.Methods.User
                             .FirstOrDefaultAsync(cancellationToken);
 
                     bool userExistsLocally = await _localContext.Users
-                        .AnyAsync(u => u.Auth0Id == getUserResponse.User.Auth0Id, cancellationToken);
+                        .AnyAsync(u => u.Auth0Id == getUserResponse.User.Auth0Id || getUserResponse.User.Id == u.Id, cancellationToken);
 
                     // Add user to the local database if the user doesn't exist locally
                     if (!userExistsLocally)

--- a/src/FocusApp.Client/Platforms/Android/MainActivity.cs
+++ b/src/FocusApp.Client/Platforms/Android/MainActivity.cs
@@ -4,7 +4,11 @@ using Android.OS;
 
 namespace FocusApp.Client
 {
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [Activity(
+        Theme = "@style/Maui.SplashTheme",
+        MainLauncher = true,
+        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density,
+        ScreenOrientation = ScreenOrientation.Portrait)]
     public class MainActivity : MauiAppCompatActivity
     {
     }

--- a/src/FocusApp.Client/Views/LoginPage.cs
+++ b/src/FocusApp.Client/Views/LoginPage.cs
@@ -183,7 +183,6 @@ internal class LoginPage : BasePage
 
             _authenticationService.SelectedIsland ??= result.Island;
             _authenticationService.SelectedPet ??= result.Pet;
-            _authenticationService.SelectedDecor ??= result.Decor;
         }
     }
 

--- a/src/FocusApp.Client/Views/Social/BadgesPage.cs
+++ b/src/FocusApp.Client/Views/Social/BadgesPage.cs
@@ -113,14 +113,6 @@ internal class BadgesPage : BasePage
     {
         base.OnAppearing();
 
-        // Check if the user is logged in
-        if (string.IsNullOrEmpty(_authenticationService.AuthToken))
-        {
-            var loginPopup = (EnsureLoginPopupInterface)_popupService.ShowAndGetPopup<EnsureLoginPopupInterface>();
-            loginPopup.OriginPage = nameof(ShopPage);
-            return;
-        }
-
         // Fetch badges from the local database and display them
         var localBadges = await FetchBadgesFromLocalDb();
         var userBadges = await FetchUserBadgesFromLocalDb();

--- a/src/FocusApp.Client/Views/Social/LeaderboardsPage.cs
+++ b/src/FocusApp.Client/Views/Social/LeaderboardsPage.cs
@@ -340,7 +340,8 @@ namespace FocusApp.Client.Views.Social
 
             _thirdPlaceUsername = new Label
             {
-                Text = "Username"
+                Text = "Username",
+                FontSize = 12
             }
             .CenterHorizontal();
 
@@ -369,7 +370,8 @@ namespace FocusApp.Client.Views.Social
             _secondPlaceUsername = new Label
             {
                 Text = "Username",
-                TextColor = Colors.Black
+                TextColor = Colors.Black,
+                FontSize = 12
             }
             .CenterHorizontal();
 
@@ -398,7 +400,8 @@ namespace FocusApp.Client.Views.Social
             _firstPlaceUsername = new Label
             {
                 Text = "Username",
-                TextColor = Colors.Black
+                TextColor = Colors.Black,
+                FontSize = 12
             }
             .CenterHorizontal();
 

--- a/src/FocusApp.Client/Views/Social/LeaderboardsPage.cs
+++ b/src/FocusApp.Client/Views/Social/LeaderboardsPage.cs
@@ -88,9 +88,9 @@ namespace FocusApp.Client.Views.Social
             {
                 RowDefinitions = GridRowsColumns.Rows.Define(
                     (PageRow.PageHeader, GridRowsColumns.Stars(1)),
-                    (PageRow.LeaderboardSelectors, GridRowsColumns.Stars(1)),
+                    (PageRow.LeaderboardSelectors, GridRowsColumns.Stars(1.15)),
                     (PageRow.TopThreeFriendsDisplay, GridRowsColumns.Stars(4.5)),
-                    (PageRow.RemainingFriendsDisplay, GridRowsColumns.Stars(3.5)),
+                    (PageRow.RemainingFriendsDisplay, GridRowsColumns.Stars(2)),
                     (PageRow.TabBarSpacer, Consts.TabBarHeight)
                     ),
                 ColumnDefinitions = GridRowsColumns.Columns.Define(
@@ -261,7 +261,7 @@ namespace FocusApp.Client.Views.Social
                 
                 Label friendName = new Label
                 {
-                    FontSize = 24,
+                    FontSize = 20,
                     VerticalOptions = LayoutOptions.Center,
                 }
                 .Column(RemainingFriendsColumn.Name);

--- a/src/FocusApp.Client/Views/Social/ProfilePage.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePage.cs
@@ -21,7 +21,7 @@ internal class ProfilePage : BasePage
     FocusAppContext _localContext;
 
     // Row / Column structure for entire page
-    enum PageRow { UserProfilePictureHeader, SelectedItems, UserDataFooter, MembershipDate, TabBarSpace }
+    enum PageRow { UserProfilePictureHeader, SelectedItems, UserDataFooter, MembershipDate }
     enum PageColumn { Left, Right }
 
     // Row / Column structure for user data header
@@ -60,11 +60,10 @@ internal class ProfilePage : BasePage
         Content = new Grid
         {
             RowDefinitions = Rows.Define(
-                (PageRow.UserProfilePictureHeader, Stars(0.75)),
+                (PageRow.UserProfilePictureHeader, Stars(0.8)),
                 (PageRow.SelectedItems, Stars(2)),
                 (PageRow.UserDataFooter, Stars(0.75)),
-                (PageRow.MembershipDate, Stars(0.35)),
-                (PageRow.TabBarSpace, Stars(0.5))
+                (PageRow.MembershipDate, Stars(0.35))
                 ),
             ColumnDefinitions = Columns.Define(
                 (PageColumn.Left, Stars(1)),
@@ -510,13 +509,13 @@ internal class ProfilePage : BasePage
     private async void SelectedDecorClicked(object sender, EventArgs eventArgs)
     {
         Shell.Current.SetTransition(Transitions.RightToLeftPlatformTransition);
-        await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{nameof(PetsPage)}");
+        await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{nameof(DecorPage)}");
     }
 
     private async void SelectedBadgeClicked(object sender, EventArgs eventArgs)
     {
         Shell.Current.SetTransition(Transitions.RightToLeftPlatformTransition);
-        await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{nameof(PetsPage)}");
+        await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{nameof(BadgesPage)}");
     }
 
     private async void BackButtonClicked(object sender, EventArgs e)

--- a/src/FocusApp.Client/Views/Social/ProfilePage.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePage.cs
@@ -416,6 +416,24 @@ internal class ProfilePage : BasePage
 
     private void CreateSelectedItemElements()
     {
+        // Selected item labels
+        _selectedPetLabel = new Label
+        {
+            Text = $"{(_authenticationService.CurrentUser?.SelectedPet?.Name == null
+                                ? "Select a pet!"
+                                : _authenticationService.CurrentUser?.SelectedPet?.Name)}",
+            FontSize = 15
+        };
+
+        _selectedIslandLabel = new Label
+        {
+            Text = $"{(_authenticationService.CurrentUser?.SelectedIsland?.Name == null
+                                ? "Select an island!"
+                                : _authenticationService.CurrentUser?.SelectedIsland?.Name)}",
+            FontSize = 15
+        };
+
+        // Selected item image buttons
         _selectedPet = new ImageButton
         {
             HeightRequest = 110,

--- a/src/FocusApp.Client/Views/Social/ProfilePage.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePage.cs
@@ -38,6 +38,10 @@ internal class ProfilePage : BasePage
     Label _email { get; set; }
 
     // Selected user item references
+    Label _selectedPetLabel { get; set; }
+    Label _selectedIslandLabel { get; set; }
+    Label _selectedDecorLabel { get; set; }
+    Label _selectedBadgeLabel { get; set; }
     ImageButton _selectedPet { get; set; }
     ImageButton _selectedIsland { get; set; }
     ImageButton _selectedDecor { get; set; }
@@ -139,14 +143,7 @@ internal class ProfilePage : BasePage
                         .Column(PageColumn.Left)
                         .Center(),
 
-                        new Label
-                        {
-                            Text = $"{
-                                (_authenticationService.CurrentUser?.SelectedPet?.Name == null
-                                ? "Select a pet!"
-                                : _authenticationService.CurrentUser?.SelectedPet?.Name)}",
-                            FontSize = 15
-                        }
+                        _selectedPetLabel
                         .Row(SelectedItemRow.Top)
                         .Column(PageColumn.Left)
                         .Top()
@@ -172,14 +169,7 @@ internal class ProfilePage : BasePage
                         .Column(PageColumn.Right)
                         .Center(),
 
-                        new Label
-                        {
-                            Text = $"{
-                                (_authenticationService.CurrentUser?.SelectedIsland?.Name == null
-                                ? "Select an island!"
-                                : _authenticationService.CurrentUser?.SelectedIsland?.Name)}",
-                            FontSize = 15
-                        }
+                        _selectedIslandLabel
                         .Row(SelectedItemRow.Top)
                         .Column(PageColumn.Right)
                         .Top()
@@ -205,14 +195,7 @@ internal class ProfilePage : BasePage
                         .Column(PageColumn.Left)
                         .Center(),
 
-                        new Label
-                        {
-                            Text = $"{
-                                (_authenticationService.CurrentUser?.SelectedDecor?.Name == null
-                                ? "Select decor!"
-                                : _authenticationService.CurrentUser?.SelectedDecor?.Name)}",
-                            FontSize = 15
-                        }
+                        _selectedDecorLabel
                         .Row(SelectedItemRow.Bottom)
                         .Column(PageColumn.Left)
                         .Top()
@@ -237,14 +220,7 @@ internal class ProfilePage : BasePage
                         .Column(PageColumn.Right)
                         .Center(),
 
-                        new Label
-                        {
-                            Text = $"{
-                                (_authenticationService.CurrentUser?.SelectedBadge?.Name == null
-                                ? "Select a badge!"
-                                : _authenticationService.CurrentUser?.SelectedBadge?.Name)}",
-                            FontSize = 15
-                        }
+                        _selectedBadgeLabel
                         .Row(SelectedItemRow.Bottom)
                         .Column(PageColumn.Right)
                         .Top()
@@ -371,13 +347,31 @@ internal class ProfilePage : BasePage
 
         // Set user selected items bindings
         _selectedPet.Source = byteArrayConverter.ConvertFrom(_authenticationService.SelectedPet?.Image);
+        _selectedPetLabel.Text = $"{(_authenticationService.SelectedPet?.Name == null
+                                        ? "Select a pet!"
+                                        : _authenticationService.SelectedPet?.Name)}";
+
         _selectedIsland.Source = byteArrayConverter.ConvertFrom(_authenticationService.SelectedIsland?.Image);
+        _selectedIslandLabel.Text = $"{(_authenticationService.SelectedIsland?.Name == null
+                                        ? "Select an island!"
+                                        : _authenticationService.SelectedIsland?.Name)}";
 
         if (_authenticationService.SelectedDecor != null)
+        {
             _selectedDecor.Source = byteArrayConverter.ConvertFrom(_authenticationService.SelectedDecor?.Image);
+            _selectedDecorLabel.Text = $"{(_authenticationService.SelectedDecor?.Name == null
+                                            ? "Select decor!"
+                                            : _authenticationService.SelectedDecor?.Name)}";
+        }
+
 
         if (_authenticationService.SelectedBadge != null)
+        {
             _selectedBadge.Source = byteArrayConverter.ConvertFrom(_authenticationService.SelectedBadge?.Image);
+            _selectedBadgeLabel.Text = $"{(_authenticationService.SelectedBadge?.Name == null
+                                            ? "Select a badge!"
+                                            : _authenticationService.SelectedBadge?.Name)}";
+        }
     }
 
 
@@ -430,6 +424,22 @@ internal class ProfilePage : BasePage
             Text = $"{(_authenticationService.CurrentUser?.SelectedIsland?.Name == null
                                 ? "Select an island!"
                                 : _authenticationService.CurrentUser?.SelectedIsland?.Name)}",
+            FontSize = 15
+        };
+
+        _selectedDecorLabel = new Label
+        {
+            Text = $"{(_authenticationService.CurrentUser?.SelectedDecor?.Name == null
+                                ? "Select decor!"
+                                : _authenticationService.CurrentUser?.SelectedDecor?.Name)}",
+            FontSize = 15
+        };
+
+        _selectedBadgeLabel = new Label
+        {
+            Text = $"{(_authenticationService.CurrentUser?.SelectedBadge?.Name == null
+                                ? "Select a badge!"
+                                : _authenticationService.CurrentUser?.SelectedBadge?.Name)}",
             FontSize = 15
         };
 

--- a/src/FocusApp.Client/Views/Social/ProfilePage.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePage.cs
@@ -472,8 +472,8 @@ internal class ProfilePage : BasePage
 
         _selectedBadge = new ImageButton
         {
-            HeightRequest = 110,
-            WidthRequest = 110
+            HeightRequest = 100,
+            WidthRequest = 100
         }
         .Bind(ImageButton.SourceProperty, "Image", converter: new ByteArrayToImageSourceConverter())
         .Invoke(button => button.Released += (sender, eventArgs) =>

--- a/src/FocusApp.Client/Views/Social/ProfilePage.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePage.cs
@@ -503,7 +503,7 @@ internal class ProfilePage : BasePage
     private async void SelectedIslandClicked(object sender, EventArgs eventArgs)
     {
         Shell.Current.SetTransition(Transitions.RightToLeftPlatformTransition);
-        await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{nameof(PetsPage)}");
+        await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{nameof(IslandsPage)}");
     }
 
     private async void SelectedDecorClicked(object sender, EventArgs eventArgs)

--- a/src/FocusApp.Client/Views/Social/ProfilePageEdit.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePageEdit.cs
@@ -235,7 +235,7 @@ internal class ProfilePageEdit : BasePage
     {
         _userNameValidationBehavior = new TextValidationBehavior
         {
-            MaximumLength = 20,
+            MaximumLength = 14,
             MinimumLength = 3,
             Flags = ValidationFlags.ValidateOnValueChanged,
             InvalidStyle = new Style<Entry>(Entry.TextColorProperty, Colors.Red),
@@ -357,11 +357,15 @@ internal class ProfilePageEdit : BasePage
 
         if (_pronounsField.Text != _authenticationService.CurrentUser?.Pronouns)
             command.Pronouns = _pronounsField.Text;
+        else if (string.IsNullOrEmpty(_pronounsField.Text) && _pronounsField.Text != _authenticationService.CurrentUser?.Pronouns)
+            command.Pronouns = _pronounsField.Text;
 
         if (_newPhoto != _authenticationService.CurrentUser?.ProfilePicture)
             command.ProfilePicture = _newPhoto;
 
-        if (!string.IsNullOrEmpty(command.Pronouns) || !string.IsNullOrEmpty(command.UserName) || command.ProfilePicture != null)
+        if (command.Pronouns is not null ||
+            !string.IsNullOrEmpty(command.UserName) ||
+            command.ProfilePicture != null)
         {
             // Call method to update the user data when the user fields have changed
             MediatrResult result = await _mediator.Send(command, default);

--- a/src/FocusApp.Client/Views/Social/ProfilePopupInterface.cs
+++ b/src/FocusApp.Client/Views/Social/ProfilePopupInterface.cs
@@ -289,8 +289,8 @@ namespace FocusApp.Client.Views.Social
             Shell.Current.SetTransition(Transitions.RightToLeftPlatformTransition);
 
             // Navigate to page within social (this allows back navigation to work properly)
+            await _popupService.HidePopupAsync<ProfilePopupInterface>();
             await Shell.Current.GoToAsync($"///{nameof(SocialPage)}/{pageName}");
-            _popupService.HidePopup();
         }
     }
 }


### PR DESCRIPTION
Fixes user selected item labels not appropriately displaying

- Leaderboards page refactoring and modification to show loading spinner
- Fixed issue in user login when a auth0 request fails and an id is not added to a user in the local context
- Removed decor given to user when continuing without login
- Added generic and async overloads to popup service
- Removed logged in check on user badges page
- Restricted username size to 14
- Reworked pronoun field validation to allow a user to remove pronouns
- Adjusted size of badge image on user profile page